### PR TITLE
Make container startup logs accessible from inside the container

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -32,7 +32,6 @@ LABEL frp.enabled="true" frp.22="tcp"
 ENV CUDA_DEVICE_ORDER PCI_BUS_ID
 # Disable device visibility by default
 ENV CUDA_VISIBLE_DEVICES -1
-ENV LOG_DIR /storage/user/container-settings/logs
 
 
 ENTRYPOINT ["/sbin/start_wrapped"]

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -22,6 +22,7 @@ RUN sed -i '/imklog/s/^/#/' /etc/rsyslog.conf
 RUN rm -f /etc/service 2> /dev/null || true
 
 COPY start_runit /sbin/
+COPY start_wrapped /sbin/
 COPY etc/ /etc/
 
 EXPOSE 22
@@ -31,7 +32,8 @@ LABEL frp.enabled="true" frp.22="tcp"
 ENV CUDA_DEVICE_ORDER PCI_BUS_ID
 # Disable device visibility by default
 ENV CUDA_VISIBLE_DEVICES -1
+ENV LOG_DIR /storage/user/container-settings/logs
 
 
-ENTRYPOINT ["/sbin/start_runit"]
+ENTRYPOINT ["/sbin/start_wrapped"]
 

--- a/base/etc/runit_init.d/02_user.sh
+++ b/base/etc/runit_init.d/02_user.sh
@@ -8,18 +8,7 @@ USER_PUBKEY=${USER_PUBKEY}
 
 USER_HOME=${BASE%"/"}/$USER_NAME
 
-set +e
-getent passwd $USER_NAME > /dev/null
-EXISTS=$?
-set -e
-
-if [ $EXISTS != 0 ]; then
-    adduser --uid=$USER_ID --home=$USER_HOME --disabled-password --gecos "" $USER_NAME
-
-    # copy default profile files if they do not exist yet
-    # (cannot use -m from adduser since folder many already exist due to mounting)
-    chpst -u $USER_NAME cp -r -n /etc/skel/. $USER_HOME/.
-fi
+getent passwd $USER_NAME || adduser --uid=$USER_ID --home=$USER_HOME --disabled-password --gecos "" $USER_NAME
 
 if [ ! -z "${USER_GROUPS}" ]; then
     # split groups into list using ',' as separator
@@ -46,6 +35,9 @@ if [ "$CURRENT_HOME_OWNER" != "$USER_NAME" ]; then
     chown $USER_NAME:$USER_NAME $USER_HOME
     chpst -u $USER_NAME chmod 750 $USER_HOME
 fi
+# copy default profile files if they do not exist yet
+# (cannot use -m from adduser since folder many already exist due to mounting)
+chpst -u $USER_NAME cp -r -n /etc/skel/. $USER_HOME/.
 
 mutex_user_lock() {
     # wait until all other users finish

--- a/base/start_wrapped
+++ b/base/start_wrapped
@@ -1,6 +1,8 @@
 #! /usr/bin/env bash
 
-logfile="$LOG_DIR/${CONTAINER_NODE:-startup}.log"
+USER_NAME=${USER_NAME:-user}
+LOG_DIR=${LOG_DIR:-/home/$USER_NAME/.containers/logs}
+LOG_FILE="$LOG_DIR/${CONTAINER_NODE:-startup}.log"
 mkdir -p "$LOG_DIR"
-truncate --size=0 "$logfile"
-start_runit > >(tee -a "$logfile") 2> >(tee -a "$logfile" >&2)
+truncate --size=0 "$LOG_FILE"
+start_runit > >(tee -a "$LOG_FILE") 2> >(tee -a "$LOG_FILE" >&2)

--- a/base/start_wrapped
+++ b/base/start_wrapped
@@ -1,0 +1,6 @@
+#! /usr/bin/env bash
+
+logfile="$LOG_DIR/${CONTAINER_NODE:-startup}.log"
+mkdir -p "$LOG_DIR"
+truncate --size=0 "$logfile"
+start_runit > >(tee -a "$logfile") 2> >(tee -a "$logfile" >&2)

--- a/base/start_wrapped
+++ b/base/start_wrapped
@@ -1,8 +1,11 @@
 #! /usr/bin/env bash
 
 USER_NAME=${USER_NAME:-user}
-LOG_DIR=${LOG_DIR:-/home/$USER_NAME/.containers/logs}
+USER_HOME=${BASE%"/"}/$USER_NAME
+
+LOG_DIR=${LOG_DIR:-"$USER_HOME/.containers/logs"}
 LOG_FILE="$LOG_DIR/${CONTAINER_NODE:-startup}.log"
+
 mkdir -p "$LOG_DIR"
 truncate --size=0 "$LOG_FILE"
 start_runit > >(tee -a "$LOG_FILE") 2> >(tee -a "$LOG_FILE" >&2)

--- a/base/start_wrapped
+++ b/base/start_wrapped
@@ -5,7 +5,25 @@ USER_HOME=${BASE%"/"}/$USER_NAME
 
 LOG_DIR=${LOG_DIR:-"$USER_HOME/.containers/logs"}
 LOG_FILE="$LOG_DIR/${CONTAINER_NODE:-startup}.log"
+LOG_LINES=${LOG_LINES:-2000}
+
+tee_first_n() {
+    local n="$1"
+    local log="$2"
+    local header="$3"
+    local count=0
+    while IFS= read -r line; do
+        if (( count < n )); then
+            echo "$header" "$line" >> "$log"
+            ((count++))
+            if (( count == n)); then
+                echo "$header" "Output truncated at '$LOG_LINES'. Set LOG_LINES to increase limit." >> "$log"
+            fi
+        fi
+        echo "$line"
+    done
+}
 
 mkdir -p "$LOG_DIR"
 truncate --size=0 "$LOG_FILE"
-start_runit > >(tee -a "$LOG_FILE") 2> >(tee -a "$LOG_FILE" >&2)
+start_runit > >(tee_first_n $LOG_LINES "$LOG_FILE" "[O]") 2> >(tee_first_n $LOG_LINES "$LOG_FILE" "[W]" >&2)


### PR DESCRIPTION
This pull request adds support for having containers' logs visible from inside the container. Log location is controlled using the environment variable `LOG_DIR`, which (in the context of `ccc-inventory`) can even be controlled by the user using `EXTRA_ENVS` in the container configuration.

Redirection and process substitution is used to make sure stdout and stderr are kept separate, and while it could be done in the existing startup script (for example by `exec > >(tee -a "$logfile") 2> >(tee -a "$logfile" >&2)`), a wrapper is created to avoid having to deal with signals.