### PR TITLE
Fix USER_GROUPS to honor requested GID when already in use

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 Changes for v1.13:
+ - bugfixes:
+	- fixed USER_GROUPS not honoring the requested GID when it was already in use (e.g. docker=998 colliding with the runit-log groups)
  - minor update:
 	- added CCC FUSE sidecar client shim integration for FUSE-enabled containers
 	- added startup relink hook for fusermount3/fusermount/fusemount helper names after package installs

--- a/base/etc/runit_init.d/02_user.sh
+++ b/base/etc/runit_init.d/02_user.sh
@@ -21,11 +21,25 @@ if [ ! -z "${USER_GROUPS}" ]; then
         GROUP_ID=${GRPUP_NAME_ID[1]}
         
         if [ ! -z "${GROUP_ID}" ]; then
-            groupadd  -f -g $GROUP_ID $GROUP_NAME
+            # Honor the exact requested GID. We intentionally avoid `groupadd -f -g`
+            # here: when the requested GID is already used by another group (e.g.
+            # GID 998/999 are taken by the runit-log groups), `-f` silently turns
+            # off `-g` and picks a different free GID, so the group ends up with
+            # the wrong ID and the user loses access to the matching resource
+            # (e.g. the host docker socket).
+            if getent group "$GROUP_NAME" > /dev/null; then
+                # group name already exists: force it to use the requested GID
+                # (-o allows the GID to be shared with an existing group)
+                groupmod -o -g "$GROUP_ID" "$GROUP_NAME"
+            else
+                # create the group with the exact GID; -o allows a non-unique GID
+                # so a pre-existing group on the same GID does not block us
+                groupadd -o -g "$GROUP_ID" "$GROUP_NAME"
+            fi
         else
-            groupadd  -f $GROUP_NAME
+            groupadd -f "$GROUP_NAME"
         fi
-        usermod -a -G $GROUP_NAME $USER_NAME
+        usermod -a -G "$GROUP_NAME" "$USER_NAME"
     done
 fi
 


### PR DESCRIPTION
## Summary
Fixed a bug where the `USER_GROUPS` configuration would not honor the exact requested GID when that GID was already in use by another group (e.g., GID 998/999 used by runit-log groups). This caused users to lose access to resources like the host docker socket.

## Key Changes
- Replaced `groupadd -f -g` with conditional logic that:
  - Uses `groupmod -o -g` to update an existing group to the requested GID
  - Uses `groupadd -o -g` to create a new group with the exact requested GID
  - The `-o` flag allows non-unique GIDs, preventing silent fallback to a different GID
- Added explanatory comments documenting why `-f` flag was problematic
- Added proper quoting around variable references for shell safety
- Simplified the no-GID case to use `groupadd -f` without the `-g` flag

## Implementation Details
The core issue was that `groupadd -f -g` silently ignores the `-g` flag when the requested GID is already in use, causing the group to be created with a different free GID instead. The fix uses `getent` to check if the group name exists and either modifies the existing group or creates a new one with the `-o` flag to allow GID sharing/override when necessary.

https://claude.ai/code/session_01XK8acD8E6RtMVR8kBwaF6X