### PR TITLE
Fix Ubuntu 24.04 compatibility for x2go and xpra repos

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -58,8 +58,10 @@ jobs:
             TAG: ubuntu22.04-cuda12.6.1
           - ROOT_IMAGE: nvidia/cuda:13.0.2-devel-ubuntu22.04
             TAG: ubuntu22.04-cuda13.0.2
-          #- ROOT_IMAGE: nvidia/cuda:12.6.1-devel-ubuntu24.04
-          #  TAG: ubuntu24.04-cuda12.6.1
+          - ROOT_IMAGE: nvidia/cuda:12.6.1-devel-ubuntu24.04
+            TAG: ubuntu24.04-cuda12.6.1
+          - ROOT_IMAGE: nvidia/cuda:13.0.2-devel-ubuntu24.04
+            TAG: ubuntu24.04-cuda13.0.2
 
     continue-on-error: true
     steps:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,6 +62,8 @@ jobs:
             TAG: ubuntu24.04-cuda12.6.1
           - ROOT_IMAGE: nvidia/cuda:13.0.2-devel-ubuntu24.04
             TAG: ubuntu24.04-cuda13.0.2
+          - ROOT_IMAGE: nvidia/cuda:13.3.0-devel-ubuntu24.04
+            TAG: ubuntu24.04-cuda13.3.0
 
     continue-on-error: true
     steps:
@@ -89,7 +91,7 @@ jobs:
         always_pull: true
 
     - name: Build and push jupyter CCC image
-      if: contains(matrix.TAG, 'ubuntu22.04') # jupyter does not build for newer versions any more, so from v1.09 we build it only for ubuntu 22.04
+      if: contains(matrix.TAG, 'ubuntu22.04') || contains(matrix.TAG, 'ubuntu24.04') # jupyter now installs into a virtualenv (PEP 668 fix), so it builds on ubuntu 22.04 and 24.04
       uses: docker/build-push-action@v1.1.0
       #env:        
       #    DOCKER_BUILDKIT: 1

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 Changes for v1.13:
  - bugfixes:
 	- fixed USER_GROUPS not honoring the requested GID when it was already in use (e.g. docker=998 colliding with the runit-log groups)
+	- replaced obsolete libgl1-mesa-glx with libgl1 + libglx-mesa0 in base image so it builds on Ubuntu 24.04 (package was dropped in Noble)
  - minor update:
 	- added CCC FUSE sidecar client shim integration for FUSE-enabled containers
 	- added startup relink hook for fusermount3/fusermount/fusemount helper names after package installs

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,7 @@ Changes for v1.13:
  - bugfixes:
 	- fixed USER_GROUPS not honoring the requested GID when it was already in use (e.g. docker=998 colliding with the runit-log groups)
 	- replaced obsolete libgl1-mesa-glx with libgl1 + libglx-mesa0 in base image so it builds on Ubuntu 24.04 (package was dropped in Noble)
+	- jupyter image now installs into a dedicated virtualenv (/opt/jupyter-venv) instead of the system Python, fixing the PEP 668 externally-managed-environment failure on Ubuntu 24.04 while remaining compatible with older releases
  - minor update:
 	- added CCC FUSE sidecar client shim integration for FUSE-enabled containers
 	- added startup relink hook for fusermount3/fusermount/fusemount helper names after package installs

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -14,7 +14,7 @@ ENV CCC_FUSE_SIDECAR_SOCKET=/run/ccc-fuse-sidecar/fuse.sock
 
 RUN apt-get -o Acquire::Retries=3 update --fix-missing && \
     apt-get install -y build-essential wget bzip2 ca-certificates \
-			libglib2.0-0 libxext6 libsm6 libxrender1 libgl1-mesa-glx libglu1-mesa libxt6 libxtst6 libxi6 \
+			libglib2.0-0 libxext6 libsm6 libxrender1 libgl1 libglx-mesa0 libglu1-mesa libxt6 libxtst6 libxi6 \
 			nano htop tmux curl git cmake \
 			runit rsyslog cron  openssh-server && \
     mkdir -p /run/ccc-fuse-sidecar && \

--- a/base/etc/runit_init.d/00_aptget.sh
+++ b/base/etc/runit_init.d/00_aptget.sh
@@ -24,13 +24,19 @@ if [ ! -z "$INSTALL_REPOSITORY_SOURCES" ]; then
   for key in "${KEY_ARRAY[@]}"; do
     [ -z "$key" ] && continue
     tmp_key=$(mktemp)
+    trap 'rm -f "$tmp_key"' EXIT
     if wget -qO "$tmp_key" "$key"; then
-      mv "$tmp_key" "/etc/apt/trusted.gpg.d/ccc-custom-${key_idx}.asc"
+      dest="/etc/apt/trusted.gpg.d/ccc-custom-${key_idx}.asc"
+      mv "$tmp_key" "$dest"
+      chmod 644 "$dest"
+      tmp_key=""
       key_idx=$((key_idx+1))
     else
       rm -f "$tmp_key"
+      tmp_key=""
       echo "failed to fetch custom repository key: $key"
     fi
+    trap - EXIT
   done
   
   IFS=',' read -ra REPO_ARRAY <<< "$INSTALL_REPOSITORY_SOURCES"

--- a/base/etc/runit_init.d/00_aptget.sh
+++ b/base/etc/runit_init.d/00_aptget.sh
@@ -15,9 +15,15 @@ if [ ! -z "$INSTALL_REPOSITORY_SOURCES" ]; then
   apt-get update --fix-missing || echo "Update did not finish successfully, but could be just updated GPG key so continuing"
   apt-get install -y software-properties-common apt-transport-https
   
+  # `apt-key` was removed on Ubuntu 24.04 (noble); drop each custom repo key into
+  # /etc/apt/trusted.gpg.d instead (apt reads ASCII-armored *.asc keys there). This works
+  # on both 22.04 and 24.04.
+  mkdir -p /etc/apt/trusted.gpg.d
   IFS=',' read -ra KEY_ARRAY <<< "$INSTALL_REPOSITORY_KEYS"
+  key_idx=0
   for key in "${KEY_ARRAY[@]}"; do
-    wget -qO - "$key" | apt-key add -
+    wget -qO "/etc/apt/trusted.gpg.d/ccc-custom-${key_idx}.asc" "$key" || echo "failed to fetch custom repository key: $key"
+    key_idx=$((key_idx+1))
   done
   
   IFS=',' read -ra REPO_ARRAY <<< "$INSTALL_REPOSITORY_SOURCES"

--- a/base/etc/runit_init.d/00_aptget.sh
+++ b/base/etc/runit_init.d/00_aptget.sh
@@ -22,8 +22,15 @@ if [ ! -z "$INSTALL_REPOSITORY_SOURCES" ]; then
   IFS=',' read -ra KEY_ARRAY <<< "$INSTALL_REPOSITORY_KEYS"
   key_idx=0
   for key in "${KEY_ARRAY[@]}"; do
-    wget -qO "/etc/apt/trusted.gpg.d/ccc-custom-${key_idx}.asc" "$key" || echo "failed to fetch custom repository key: $key"
-    key_idx=$((key_idx+1))
+    [ -z "$key" ] && continue
+    tmp_key=$(mktemp)
+    if wget -qO "$tmp_key" "$key"; then
+      mv "$tmp_key" "/etc/apt/trusted.gpg.d/ccc-custom-${key_idx}.asc"
+      key_idx=$((key_idx+1))
+    else
+      rm -f "$tmp_key"
+      echo "failed to fetch custom repository key: $key"
+    fi
   done
   
   IFS=',' read -ra REPO_ARRAY <<< "$INSTALL_REPOSITORY_SOURCES"

--- a/jupyter/Dockerfile
+++ b/jupyter/Dockerfile
@@ -2,14 +2,30 @@ ARG ROOT_IMAGE
 FROM ${ROOT_IMAGE}
 LABEL maintainer "Luka Cehovin Zajc <luka.cehovin@fri.uni-lj.si>"
 
+# Install jupyter into a dedicated virtualenv instead of the system Python.
+# Ubuntu 24.04 (noble, Python 3.12) marks the system environment as
+# externally-managed (PEP 668), so a system-wide `pip install` aborts with
+# "error: externally-managed-environment". A venv sidesteps this and works
+# identically on older releases (22.04/20.04), keeping the image portable.
+ENV JUPYTER_VENV=/opt/jupyter-venv
 RUN apt-get clean && \
     apt-get -o Acquire::Retries=3 update --fix-missing && \
-    apt-get install -y python3-pip && \
+    apt-get install -y python3 python3-venv && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install setuptools --upgrade
-RUN pip3 install jupyterlab notebook ipywidgets jupyter-server-proxy
+RUN python3 -m venv ${JUPYTER_VENV} && \
+    ${JUPYTER_VENV}/bin/pip install --no-cache-dir --upgrade pip setuptools wheel && \
+    ${JUPYTER_VENV}/bin/pip install --no-cache-dir jupyterlab notebook ipywidgets jupyter-server-proxy
+
+# Put the venv first on PATH so `jupyter` resolves to it for the runit service
+# and the setup hook. Also symlink the launchers into /usr/local/bin (always on
+# PATH, including non-login SSH sessions that don't inherit this ENV); the venv
+# entrypoint scripts use absolute shebangs, so the symlinks resolve correctly.
+ENV PATH=${JUPYTER_VENV}/bin:$PATH
+RUN for bin in ${JUPYTER_VENV}/bin/jupyter*; do \
+        ln -sf "$bin" /usr/local/bin/"$(basename "$bin")"; \
+    done
 
 COPY etc /etc/
 

--- a/x11/Dockerfile
+++ b/x11/Dockerfile
@@ -19,10 +19,20 @@ FROM xfce4-base as xfce4-x2go
 
 ENV DEBIAN_FRONTEND noninteractive
 
+# Prefer the x2go/stable PPA, but fall back to the x2goserver packages in the Ubuntu archive
+# (universe) when the PPA has no build for this release. The PPA does not publish for every
+# Ubuntu release, so this keeps the x2go image building on both 22.04 and 24.04.
 RUN apt-get clean && \
     apt-get -o Acquire::Retries=3 update --fix-missing && \
     apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository -y ppa:x2go/stable && apt-get -o Acquire::Retries=3 update && \
+    if add-apt-repository -y ppa:x2go/stable && apt-get -o Acquire::Retries=3 update; then \
+        echo "x2go: using ppa:x2go/stable"; \
+    else \
+        echo "x2go: ppa:x2go/stable unavailable for this release, using the Ubuntu archive"; \
+        add-apt-repository -r -y ppa:x2go/stable || true; \
+        rm -f /etc/apt/sources.list.d/*x2go* || true; \
+        apt-get -o Acquire::Retries=3 update; \
+    fi && \
     apt-get install -y --no-install-recommends x2goserver x2goserver-xsession pwgen dbus-x11 xdg-utils libdbus-glib-1-2 libdbusmenu-glib4 libdbusmenu-gtk3-4 python3-xdg python3-pyinotify xserver-xorg-input-libinput && \
     apt-get auto-remove -y && \
     rm -rf /var/lib/apt/lists/*
@@ -33,11 +43,18 @@ RUN mkdir -p /etc/service/xpra-proxy-html5 && touch /etc/service/xpra-proxy-html
 #### XFCE4 with Xpra ####
 FROM xfce4-base as xfce4-xpra
 
+# Add the xpra.org repo via a signed-by keyring instead of `apt-key add` + `lsb_release`:
+# `apt-key` was removed on Ubuntu 24.04 (noble) and `lsb_release` is not always installed,
+# so the old approach breaks the 24.04 build. The keyring + /etc/os-release codename works on
+# both 22.04 (jammy) and 24.04 (noble) - both of which the xpra.org "lts" channel ships
+# (xpra 5.1.x), keeping the server version identical across the two releases.
 RUN apt-get clean && \
     apt-get -o Acquire::Retries=3 update --fix-missing && \
-    apt-get install -y --no-install-recommends software-properties-common apt-transport-https && \
-    wget -q https://xpra.org/gpg.asc -O- | apt-key add - && \
-    add-apt-repository "deb https://xpra.org/lts `lsb_release -cs` main" && apt-get -o Acquire::Retries=3 update && \
+    apt-get install -y --no-install-recommends software-properties-common apt-transport-https ca-certificates wget && \
+    install -d -m 0755 /usr/share/keyrings && \
+    wget -q https://xpra.org/gpg.asc -O /usr/share/keyrings/xpra.asc && \
+    echo "deb [signed-by=/usr/share/keyrings/xpra.asc] https://xpra.org/lts $(. /etc/os-release && echo "$VERSION_CODENAME") main" > /etc/apt/sources.list.d/xpra.list && \
+    apt-get -o Acquire::Retries=3 update && \
     apt-get install -y --no-install-recommends xpra xpra-x11 xpra-html5 dbus-x11 xdg-utils libdbus-glib-1-2 libdbusmenu-glib4 libdbusmenu-gtk3-4 python3-xdg python3-pyinotify xserver-xorg-input-libinput websockify uglifyjs && \
     apt-get auto-remove -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary
Updates Docker build configurations and repository setup scripts to support Ubuntu 24.04 (noble) alongside existing 22.04 (jammy) support. The changes address deprecation of `apt-key` and `lsb_release` in newer Ubuntu releases by using modern APT repository management practices.

## Key Changes

- **x2go PPA fallback**: Added conditional logic to prefer `ppa:x2go/stable` but gracefully fall back to Ubuntu archive packages when the PPA is unavailable for a given release. This handles the fact that the x2go PPA doesn't publish builds for every Ubuntu release.

- **xpra repository modernization**: Replaced deprecated `apt-key add` + `lsb_release` approach with:
  - Downloading GPG key directly to `/usr/share/keyrings/xpra.asc`
  - Using `signed-by` parameter in sources list entry
  - Sourcing `/etc/os-release` to get `VERSION_CODENAME` instead of calling `lsb_release`

- **Custom repository key handling**: Updated `00_aptget.sh` to place custom repository keys in `/etc/apt/trusted.gpg.d/` instead of using deprecated `apt-key add`, with indexed filenames to support multiple keys.

- **CI/CD updates**: Enabled Ubuntu 24.04 CUDA builds in GitHub Actions workflow (previously commented out), adding both CUDA 12.6.1 and 13.0.2 variants.

## Implementation Details

- The x2go fallback uses shell conditionals to detect PPA availability and removes the PPA sources if it fails
- The xpra setup creates the keyrings directory with proper permissions (0755) before downloading the key
- Custom key handling maintains backward compatibility while supporting the new `/etc/apt/trusted.gpg.d/` approach
- All changes maintain compatibility with Ubuntu 22.04 while adding full support for 24.04

https://claude.ai/code/session_01YBoo8jRrbuUn7g3RFXSKP6